### PR TITLE
Add debugcommands to the coop preset

### DIFF
--- a/etc/battlePresets.conf
+++ b/etc/battlePresets.conf
@@ -59,6 +59,7 @@ description:Coop PvE Game Battle Settings
 resetoptions:1
 disabledunits:-*
 startpostype:2|0|1
+debugcommands:|~.*
 tweakdefs:|~[A-Za-z0-9\-\_]*
 tweakdefs1:|~[A-Za-z0-9\-\_]*
 tweakdefs2:|~[A-Za-z0-9\-\_]*


### PR DESCRIPTION
This updates the coop battle preset to allow the use of debugcommands.

### Issue
Currently, players who want to set up a Coop vs AI lobby with terrain modifiers need to use either the team or custom presets.
 **This presents the following issue:**
 -The lobby balance must be disabled to ensure all AIs are placed on a single team.
 -Disabling balance can result in player IDs overlapping with AI IDs. 
### The current workaround:
 -Wait for the lobby to fill with the exact number of players. 
 -Lock the lobby.
 -Remove and then re-add the AI. (If an extra player is in que, they will join and take an AI spot when re-adding the AI.)
### Solution:
By enabling debugcommands in the coop preset, players can set up coop vs AI lobbies with terrain modifiers and proper balance settings, simplifying the process. We could also consider adding debugcommands to FFA.

